### PR TITLE
Improve clarity of model run command's error message

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -227,6 +227,7 @@ func NewRunCommand() *cobra.Command {
 			}
 
 			noMatchErrorMessage := "The specified model name is not found. Run 'gh models list' to see available models or 'gh models run' to select interactively."
+
 			if modelName == "" {
 				return errors.New(noMatchErrorMessage)
 			}


### PR DESCRIPTION
closes: github/models#322

Adds more detail to the error output when a given model name is either empty or otherwise not found. 

----

Before (taken from issue):

```
$ gh models run ThisDoesNotExist Mary had a little lamb
Error: bad request
{"error":{"code":"unknown_model","message":"Unknown model: thisdoesnotexist","details":null}}

Usage:
  gh run [model] [prompt] [flags]

Flags:
  -h, --help                   help for run
      --max-tokens string      Limit the maximum tokens for the model response.
      --system-prompt string   Prompt the system.
      --temperature string     Controls randomness in the response, use lower to be more deterministic.
      --top-p string           Controls text diversity by selecting the most probable words until a set probability is reached.

```

----

After:

```
danielgarman:Daniel’s MacBook Pro
╰─\gh-models:models/322-improve-error-messaging-root*:% ./gh-models run "" "mary had a little lamb"
Error: The specified model name is not found. Run 'gh models list' to see available models or 'gh models run' to select interactively.
Usage:
  gh run [model] [prompt] [flags]

Flags:
  -h, --help                   help for run
      --max-tokens string      Limit the maximum tokens for the model response.
      --system-prompt string   Prompt the system.
      --temperature string     Controls randomness in the response, use lower to be more deterministic.
      --top-p string           Controls text diversity by selecting the most probable words until a set probability is reached.

danielgarman:Daniel’s MacBook Pro
╰─\gh-models:models/322-improve-error-messaging-root*:% ./gh-models run "asdfasdf" "mary had a little lamb"
Error: The specified model name is not found. Run 'gh models list' to see available models or 'gh models run' to select interactively.
Usage:
  gh run [model] [prompt] [flags]

Flags:
  -h, --help                   help for run
      --max-tokens string      Limit the maximum tokens for the model response.
      --system-prompt string   Prompt the system.
      --temperature string     Controls randomness in the response, use lower to be more deterministic.
      --top-p string           Controls text diversity by selecting the most probable words until a set probability is reached.
```

or

```
danielgarman:Daniel’s MacBook Pro
╰─\gh-models:models/322-improve-error-messaging-root:% ./gh-models run foo "hello world"
Error: The specified model name is not found. Run 'gh models list' to see available models or 'gh models run' to select interactively.
Usage:
  gh run [model] [prompt] [flags]

Flags:
  -h, --help                   help for run
      --max-tokens string      Limit the maximum tokens for the model response.
      --system-prompt string   Prompt the system.
      --temperature string     Controls randomness in the response, use lower to be more deterministic.
      --top-p string           Controls text diversity by selecting the most probable words until a set probability is reached.
```