### PR TITLE
Upcase the column headers when listing models

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -55,7 +55,7 @@ func NewListCommand() *cobra.Command {
 			width, _, _ := terminal.Size()
 			printer := tableprinter.New(out, isTTY, width)
 
-			printer.AddHeader([]string{"Display Name", "Model Name"}, tableprinter.WithColor(lightGrayUnderline))
+			printer.AddHeader([]string{"DISPLAY NAME", "MODEL NAME"}, tableprinter.WithColor(lightGrayUnderline))
 			printer.EndRow()
 
 			for _, model := range models {


### PR DESCRIPTION
closes: github/models#319

Upcases the column headings in `gh models list` to match the standard from other commands like `gh repo list`