### PR TITLE
[GitHub models] Rename models root command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"github.com/github/gh-models/cmd/list"
 	"github.com/github/gh-models/cmd/run"
 	"github.com/spf13/cobra"
+	"strings"
 )
 
 func NewRootCommand() *cobra.Command {
@@ -15,5 +16,10 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(list.NewListCommand())
 	cmd.AddCommand(run.NewRunCommand())
 
+	// Cobra doesn't have a way to specify a two word command (ie. "gh models"), so set a custom usage template
+	// with `gh`` in it. Cobra will use this template for the root and all child commands.
+	cmd.SetUsageTemplate(strings.NewReplacer(
+		"{{.UseLine}}", "gh {{.UseLine}}",
+		"{{.CommandPath}}", "gh {{.CommandPath}}").Replace(cmd.UsageTemplate()))
 	return cmd
 }


### PR DESCRIPTION
- Closes https://github.com/github/models/issues/318

Interestingly, it seems like it's not possible to have a multi word usage command for a single command: https://github.com/spf13/cobra/issues/1057

We have a few options:

- I looked at the way other extensions do it and they seem to use hyphenated words, which isn't exactly right. For example, [gh-discussions](https://github.com/github/gh-discussions/blob/main/cmd/root.go#L17) uses the command `gh-discussions` which looks like this and isn't exactly right because running `gh-discussions edit` is not a valid command

```
@Deborah-Digges ➜ /workspaces/gh-models $ gh discussions --help
A CLI for GitHub Discussions
While not complete by any means, this CLI is intended to provide a quick way to
interact with GitHub Discussions from the GH CLI. PRs welcome!

Usage:
  gh-discussions [flags]
  gh-discussions [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  create      Create a discusson from the command line.
  edit        Edit a discusson from the command line.
  help        Help about any command
```

- The other option could be to change it to just be `models`, such that the help command looks like this. This feels more correct than the previous option:

```
@Deborah-Digges ➜ /workspaces/gh-models $ gh models --help
GitHub Models extension

Usage:
  models [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  list        List available models
  run         Run inference with the specified model

Flags:
  -h, --help   help for models

Use "models [command] --help" for more information about a command.
```