### PR TITLE
Pin cli/gh-extension-precompile workflow version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cli/gh-extension-precompile@v2
+      - uses: cli/gh-extension-precompile@561b19deda1228a0edf856c3325df87416f8c9bd
         with:
           go_version: "1.22"
           release_tag: ${{ github.event.inputs.release_tag || '' }}


### PR DESCRIPTION
Closes https://github.com/github/gh-models/security/code-scanning/5. I went to https://github.com/cli/gh-extension-precompile/releases/tag/v2.0.0 and got the commit sha for that release.