### PR TITLE
Update CODEOWNERS, fix lint workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @github/bento-reviewers
+* @github/github-models-reviewers

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,10 +31,10 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           check-latest: true
-      - uses: actions/checkout@v4
       - name: Lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: "go-linter"
+name: "Lint"
 
 on:
   pull_request:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ on:
       - "**.go"
       - go.mod
       - go.sum
+      - .github/workflows/lint.yml
   merge_group:
   workflow_dispatch:
   push:
@@ -15,7 +16,7 @@ on:
     paths:
       - "**.go"
       - go.mod
-      - go.sum
+      - .github/workflows/lint.yml
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,11 +29,6 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
-    env:
-      GOPROXY: https://proxy.golang.org/,direct
-      GOPRIVATE: ""
-      GONOPROXY: ""
-      GONOSUMDB: github.com/github/*
     steps:
       - uses: actions/setup-go@v5
         with:
@@ -41,9 +36,4 @@ jobs:
           check-latest: true
       - uses: actions/checkout@v4
       - name: Lint
-        # This also does checkout, setup-go, and proxy setup.
-        uses: github/go-linter@v1.2.1
-        with:
-          strict: true
-          go-version: ${{ vars.GOVERSION }}
-          goproxy-token: ${{secrets.GOPROXY_TOKEN}}
+        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,19 @@ name: "go-linter"
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - "**.go"
+      - go.mod
+      - go.sum
   merge_group:
   workflow_dispatch:
   push:
     branches:
       - 'main'
+    paths:
+      - "**.go"
+      - go.mod
+      - go.sum
 
 permissions:
   contents: read
@@ -29,7 +37,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ vars.GOVERSION }}
+          go-version-file: 'go.mod'
           check-latest: true
       - uses: actions/checkout@v4
       - name: Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - "**.go"
       - go.mod
+      - go.sum
       - .github/workflows/lint.yml
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,10 +32,11 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-          check-latest: true
       - name: Lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8

--- a/internal/azuremodels/azure_client_test.go
+++ b/internal/azuremodels/azure_client_test.go
@@ -45,7 +45,8 @@ func TestAzureClient(t *testing.T) {
 				err := json.NewEncoder(data).Encode(&ChatCompletion{Choices: []ChatChoice{choice}})
 				require.NoError(t, err)
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("data: " + data.String() + "\n\ndata: [DONE]\n"))
+				_, err = w.Write([]byte("data: " + data.String() + "\n\ndata: [DONE]\n"))
+				require.NoError(t, err)
 			}))
 			defer testServer.Close()
 			cfg := &AzureClientConfig{InferenceURL: testServer.URL}
@@ -107,18 +108,21 @@ func TestAzureClient(t *testing.T) {
 				data1 := new(bytes.Buffer)
 				err := json.NewEncoder(data1).Encode(&ChatCompletion{Choices: []ChatChoice{choice1}})
 				require.NoError(t, err)
-				w.Write([]byte("data: " + data1.String() + "\n\n"))
+				_, err = w.Write([]byte("data: " + data1.String() + "\n\n"))
+				require.NoError(t, err)
 				w.(http.Flusher).Flush()
 				time.Sleep(1 * time.Millisecond)
 
 				data2 := new(bytes.Buffer)
 				err = json.NewEncoder(data2).Encode(&ChatCompletion{Choices: []ChatChoice{choice2}})
 				require.NoError(t, err)
-				w.Write([]byte("data: " + data2.String() + "\n\n"))
+				_, err = w.Write([]byte("data: " + data2.String() + "\n\n"))
+				require.NoError(t, err)
 				w.(http.Flusher).Flush()
 				time.Sleep(1 * time.Millisecond)
 
-				w.Write([]byte("data: [DONE]\n"))
+				_, err = w.Write([]byte("data: [DONE]\n"))
+				require.NoError(t, err)
 			}))
 			defer testServer.Close()
 			cfg := &AzureClientConfig{InferenceURL: testServer.URL}
@@ -165,7 +169,8 @@ func TestAzureClient(t *testing.T) {
 			errRespBody := `{"error": "o noes"}`
 			testServer := newTestServerForChatCompletion(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(errRespBody))
+				_, err := w.Write([]byte(errRespBody))
+				require.NoError(t, err)
 			}))
 			defer testServer.Close()
 			cfg := &AzureClientConfig{InferenceURL: testServer.URL}
@@ -255,7 +260,8 @@ func TestAzureClient(t *testing.T) {
 			errRespBody := `{"error": "o noes"}`
 			testServer := newTestServerForListModels(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusUnauthorized)
-				w.Write([]byte(errRespBody))
+				_, err := w.Write([]byte(errRespBody))
+				require.NoError(t, err)
 			}))
 			defer testServer.Close()
 			cfg := &AzureClientConfig{ModelsURL: testServer.URL}
@@ -336,7 +342,8 @@ func TestAzureClient(t *testing.T) {
 			errRespBody := `{"error": "o noes"}`
 			testServer := newTestServerForModelDetails(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(errRespBody))
+				_, err := w.Write([]byte(errRespBody))
+				require.NoError(t, err)
 			}))
 			defer testServer.Close()
 			cfg := &AzureClientConfig{AzureAiStudioURL: testServer.URL}


### PR DESCRIPTION
This loops in a broader group of code reviewers when files in the repo are changed. I also updated the lint workflow because I noticed it was failing in the setup stage with "Error: Unable to resolve action `github/go-linter`, not found".