### PR TITLE
Update the release.yml workflow to add more gh-extension-precompile functionality

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,5 +19,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cli/gh-extension-precompile@561b19deda1228a0edf856c3325df87416f8c9bd
         with:
-          go_version: "1.22"
+          go_version_file: go.mod
           release_tag: ${{ github.event.inputs.release_tag || '' }}
+          generate_attestations: true


### PR DESCRIPTION
This PR aims to use more of the [gh-extension-precompile](https://github.com/cli/gh-extension-precompile) functionality when cutting a new release. Namely:

1. Changes `go_version` to `go_version_file: go.mod` to remove a hardcoding of version number
1. Adds `generate_attestations: true` so interested parties can verify the release was created by an action