### PR TITLE
Include initial prompt when interpolating `{{input}}` in prompt.yaml files

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -270,6 +270,7 @@ func NewRunCommand(cfg *command.Config) *cobra.Command {
 			if isPipe(os.Stdin) {
 				promptFromPipe, _ := io.ReadAll(os.Stdin)
 				if len(promptFromPipe) > 0 {
+					singleShot = true
 					pipedContent = strings.TrimSpace(string(promptFromPipe))
 					if initialPrompt != "" {
 						initialPrompt = initialPrompt + "\n" + pipedContent

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -271,9 +271,10 @@ func NewRunCommand(cfg *command.Config) *cobra.Command {
 				promptFromPipe, _ := io.ReadAll(os.Stdin)
 				if len(promptFromPipe) > 0 {
 					pipedContent = strings.TrimSpace(string(promptFromPipe))
-					if pf == nil {
+					if initialPrompt != "" {
 						initialPrompt = initialPrompt + "\n" + pipedContent
-						singleShot = true
+					} else {
+						initialPrompt = pipedContent
 					}
 				}
 			}
@@ -291,8 +292,8 @@ func NewRunCommand(cfg *command.Config) *cobra.Command {
 			if pf != nil {
 				for _, m := range pf.Messages {
 					content := m.Content
-					if pipedContent != "" && strings.ToLower(m.Role) == "user" {
-						content = strings.ReplaceAll(content, "{{input}}", pipedContent)
+					if strings.ToLower(m.Role) == "user" {
+						content = strings.ReplaceAll(content, "{{input}}", initialPrompt)
 					}
 					switch strings.ToLower(m.Role) {
 					case "system":

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -222,7 +222,7 @@ messages:
 
 		require.Len(t, capturedReq.Messages, 3)
 		require.Equal(t, "You are a text summarizer.", *capturedReq.Messages[0].Content)
-		require.Equal(t, initialPrompt+"\n"+piped, *capturedReq.Messages[1].Content) // {{input}} -> "Hello there!"
+		require.Equal(t, initialPrompt+"\n"+piped, *capturedReq.Messages[1].Content) // {{input}} -> "Please summarize the provided text.\nHello there!"
 
 		require.Contains(t, out.String(), reply)
 	})

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/text v0.23.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -49,5 +50,4 @@ require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/term v0.30.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Hello!

## What?

This PR makes it so that the text that is substituted when interpolating `{{input}}` templates inside prompt.yaml files includes whatever got piped in **AND** the "initial prompt", i.e. the text that is passed in via the positional args.

## Why?

I am stringing `gh models run` together as a cli util for my own GitHub work related purposes, and I like the idea of having templated system prompts I can swap out at will. I've seen a few people online claim that messing with system prompts is where a lot of the "juice" is, and I find that for ex. the default gpt-4o behaviour is overly verbose and obsequious.

Initially, using `--file prompt.yaml` seemed pretty ideal for this. However, I quickly discovered that the `{{input}}` template was not being populated with the contents of the "initialPrompt" – only with whatever got piped in.

This made it inconvenient to use with my intended use case, i.e. something like this:

```
alias gmr="gh models run openai/gpt-4o --file prompts/default.prompt.yaml"

cat whatever.txt | grm sample prompt here but for example let's say translate this file into ruby
```

Without this change, the specific request to "translate this file into ruby" gets ignored.

## Additional improvements

Typing this out, I feel like that _this should be the default behaviour_, i.e. even if the provided prompt.yaml does not specify an `{{input}}` field but the `run` command receives piped or prompted content, then we should throw that in as user message. If I am feeling frisky maybe I could add that in a future PR.