### PR TITLE
Minor refactor, simplified how "interactive" mode works

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -326,6 +326,8 @@ func NewRunCommand(cfg *command.Config) *cobra.Command {
 					conversation, err = cmdHandler.ChatWithUser(conversation, mp)
 					if errors.Is(err, ExitChatError) {
 						break
+					} else if errors.Is(err, io.EOF) {
+						break
 					} else if err != nil {
 						return err
 					}

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -293,17 +293,11 @@ func NewRunCommand(cfg *command.Config) *cobra.Command {
 			if pf != nil {
 				for _, m := range pf.Messages {
 					content := m.Content
-					if strings.ToLower(m.Role) == "user" {
-						content = strings.ReplaceAll(content, "{{input}}", initialPrompt)
-					}
 					switch strings.ToLower(m.Role) {
 					case "system":
-						if conversation.systemPrompt == "" {
-							conversation.systemPrompt = content
-						} else {
-							conversation.AddMessage(azuremodels.ChatMessageRoleSystem, content)
-						}
+						conversation.systemPrompt = content
 					case "user":
+						content = strings.ReplaceAll(content, "{{input}}", initialPrompt)
 						conversation.AddMessage(azuremodels.ChatMessageRoleUser, content)
 					case "assistant":
 						conversation.AddMessage(azuremodels.ChatMessageRoleAssistant, content)

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -326,7 +326,7 @@ func NewRunCommand(cfg *command.Config) *cobra.Command {
 			for {
 				if interactiveMode {
 					conversation, err = cmdHandler.ChatWithUser(conversation, mp)
-					if errors.Is(err, ExitChatError) {
+					if errors.Is(err, ErrExitChat) {
 						break
 					} else if errors.Is(err, io.EOF) {
 						break
@@ -571,7 +571,7 @@ func (h *runCommandHandler) writeToOut(message string) {
 	h.cfg.WriteToOut(message)
 }
 
-var ExitChatError = errors.New("exiting chat")
+var ErrExitChat = errors.New("exiting chat")
 
 func (h *runCommandHandler) ChatWithUser(conversation Conversation, mp ModelParameters) (Conversation, error) {
 	fmt.Printf(">>> ")
@@ -589,7 +589,7 @@ func (h *runCommandHandler) ChatWithUser(conversation Conversation, mp ModelPara
 
 	if strings.HasPrefix(prompt, "/") {
 		if prompt == "/bye" || prompt == "/exit" || prompt == "/quit" {
-			return conversation, ExitChatError
+			return conversation, ErrExitChat
 		}
 
 		if prompt == "/parameters" {

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -326,9 +326,7 @@ func NewRunCommand(cfg *command.Config) *cobra.Command {
 			for {
 				if interactiveMode {
 					conversation, err = cmdHandler.ChatWithUser(conversation, mp)
-					if errors.Is(err, ErrExitChat) {
-						break
-					} else if errors.Is(err, io.EOF) {
+					if errors.Is(err, ErrExitChat) || errors.Is(err, io.EOF) {
 						break
 					} else if err != nil {
 						return err

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -139,7 +139,7 @@ messages:
 		_, err = runCmd.ExecuteC()
 		require.NoError(t, err)
 
-		require.Equal(t, 3, len(capturedReq.Messages))
+		require.Equal(t, 2, len(capturedReq.Messages))
 		require.Equal(t, "You are a text summarizer.", *capturedReq.Messages[0].Content)
 		require.Equal(t, "Hello there!", *capturedReq.Messages[1].Content)
 
@@ -220,7 +220,7 @@ messages:
 		_, err = runCmd.ExecuteC()
 		require.NoError(t, err)
 
-		require.Len(t, capturedReq.Messages, 3)
+		require.Len(t, capturedReq.Messages, 2)
 		require.Equal(t, "You are a text summarizer.", *capturedReq.Messages[0].Content)
 		require.Equal(t, initialPrompt+"\n"+piped, *capturedReq.Messages[1].Content) // {{input}} -> "Please summarize the provided text.\nHello there!"
 


### PR DESCRIPTION
## What?

This PR:
- Cleans up how the initialPrompt var was used to be more straightforward, instead of resetting the variable to an empty string and using that as a kind of way of tracking state.
- Tidies up the "chat for loop" so it just calls a function
- Most significantly afaict "singleShot" actually just meant "active the chat interface" so I renamed it to `interactiveMode`.

## Why?

I'm using this extension to teach myself some LLM-oriented workflows. I'm writing little shell scripts to have an AI companion in my CLI, and trying to figure out how to get the LLM to do most of the heavy lifting. I am thinking of proposing & then implementing some additional features to this extension (i.e. I think I might want to be able to pipe context in _and_ have an interactive mode).

Ahead of those proposals, and to flex a little with LLMs, I decided to do some light refactoring. I like to keep my PRs small and bite-sized, so apologies if I create a few of these just tidying things up.

