### PR TITLE
Values from flags should override values in prompt yaml files.

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -314,15 +314,16 @@ func NewRunCommand(cfg *command.Config) *cobra.Command {
 			}
 
 			mp := ModelParameters{}
-			err = mp.PopulateFromFlags(cmd.Flags())
-			if err != nil {
-				return err
-			}
 
 			if pf != nil {
 				mp.maxTokens = pf.ModelParameters.MaxTokens
 				mp.temperature = pf.ModelParameters.Temperature
 				mp.topP = pf.ModelParameters.TopP
+			}
+
+			err = mp.PopulateFromFlags(cmd.Flags())
+			if err != nil {
+				return err
 			}
 
 			for {

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -317,7 +317,6 @@ messages:
 			"--max-tokens", "150",
 			"--temperature", "0.1",
 			"--top-p", "0.3",
-			azuremodels.FormatIdentifier("openai", "example-model"),
 		})
 
 		_, err = runCmd.ExecuteC()


### PR DESCRIPTION
## What?

Very small follow up from #48:

- If a user supplies a cli flag and a prompt.yaml file, then the value from the flag should override the value from the prompt.yaml file

## Why?

Suppose I have a template in a prompt.yaml that defines model parameters (or even model name). If I want to iterate on the temperature, or even _which model i want to use_ then it's easier to do so by repeatedly running the cmd and tweaking the flag value.

Basically, a cli flag has a higher order of "specificity" than the value in the yaml file. I'm _more intentional_, it is **surprising** that the cli flag value might be silently ignored.

## Bonus observation

About 80% of this test was written via the following prompt:

```bash
cb $(ctx show) | ai "add a test suite to for the run_test.go file. the test should ensure that a modelParemeter specified in a prompt.yaml file can be overridden by the values passed in to the command\'s --flags."
```