### PR TITLE
Add android-arm64 to release scripts

### DIFF
--- a/script/build
+++ b/script/build
@@ -28,6 +28,8 @@ fi
 
 if [[ "$OS" == "linux" || "$OS" == "all" ]]; then
     GOOS=linux GOARCH=amd64 build
+    GOOS=android GOARCH=arm64 build
+    GOOS=android GOARCH=amd64 build
 fi
 
 if [[ "$OS" == "darwin" || "$OS" == "all" ]]; then

--- a/script/upload-release
+++ b/script/upload-release
@@ -11,6 +11,6 @@ if [ -z $TAG ]; then
 fi
 shift
 
-BINARIES="gh-models-darwin-amd64 gh-models-darwin-arm64 gh-models-linux-amd64 gh-models-windows-amd64.exe"
+BINARIES="gh-models-darwin-amd64 gh-models-darwin-arm64 gh-models-linux-amd64 gh-models-windows-amd64.exe gh-models-android-arm64 gh-models-android-amd64"
 
 gh release upload $* $TAG $BINARIES


### PR DESCRIPTION
https://github.com/github/gh-models/issues/43

Build the extension for android-arm64. Builds fine locally so I assume it'll build and release in CI as well.