### PR TITLE
Drop /en from docs URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ gh models eval my_prompt.prompt.yml --json
 
 The JSON output includes detailed test results, evaluation scores, and summary statistics that can be processed by other tools or CI/CD pipelines.
 
-Learn more about `.prompt.yml` files here: [Storing prompts in GitHub repositories](https://docs.github.com/en/github-models/use-github-models/storing-prompts-in-github-repositories).
+Learn more about `.prompt.yml` files here: [Storing prompts in GitHub repositories](https://docs.github.com/github-models/use-github-models/storing-prompts-in-github-repositories).
 
 ## Notice
 


### PR DESCRIPTION
If we omit the `/en` in the GitHub docs URL, then if there's a non-English translation available and the user's browser requests that other language, we'll render our docs in the user's preferred language instead of defaulting them to English.

Context: https://github.com/github/gh-models/pull/57/files#r2129664982