### PR TITLE
Support templates in our string evaluators

### DIFF
--- a/cmd/eval/eval_test.go
+++ b/cmd/eval/eval_test.go
@@ -129,7 +129,7 @@ evaluators:
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				result, err := handler.runStringEvaluator("test", tt.evaluator, tt.response)
+				result, err := handler.runStringEvaluator("test", tt.evaluator, map[string]interface{}{}, tt.response)
 				require.NoError(t, err)
 				require.Equal(t, tt.expected, result.Passed)
 				if tt.expected {

--- a/cmd/eval/eval_test.go
+++ b/cmd/eval/eval_test.go
@@ -88,6 +88,7 @@ evaluators:
 			evaluator prompt.StringEvaluator
 			response  string
 			expected  bool
+			variables map[string]interface{}
 		}{
 			{
 				name:      "contains match",
@@ -125,11 +126,25 @@ evaluators:
 				response:  "hello world",
 				expected:  true,
 			},
+			{
+				name:      "contains with variable",
+				evaluator: prompt.StringEvaluator{Contains: "{{expected}}"},
+				response:  "hello world",
+				expected:  true,
+				variables: map[string]interface{}{"expected": "world"},
+			},
+			{
+				name:      "fails with variable not match",
+				evaluator: prompt.StringEvaluator{Contains: "{{expected}}"},
+				response:  "hello world",
+				expected:  false,
+				variables: map[string]interface{}{"expected": "goodbye"},
+			},
 		}
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				result, err := handler.runStringEvaluator("test", tt.evaluator, map[string]interface{}{}, tt.response)
+				result, err := handler.runStringEvaluator("test", tt.evaluator, tt.variables, tt.response)
 				require.NoError(t, err)
 				require.Equal(t, tt.expected, result.Passed)
 				if tt.expected {

--- a/examples/sample_prompt.yml
+++ b/examples/sample_prompt.yml
@@ -6,8 +6,10 @@ modelParameters:
   maxTokens: 50
 testData:
   - input: 'hello world'
+    string: hello
     expected: 'greeting response'
   - input: 'goodbye world'
+    string: goodbye
     expected: 'farewell response'
 messages:
   - role: system
@@ -17,6 +19,6 @@ messages:
 evaluators:
   - name: string evaluator
     string:
-      contains: world
+      contains: '{{string}}'
   - name: similarity check
     uses: github/similarity


### PR DESCRIPTION
Much like our web prompt tooling, we should allow the models cli to support templated variables in string evaluators.

__*Before*__

```
Running test case 1/1...
  ✗ FAILED
    Model Response: Goodbye! Take care and see you next time! 🌍👋
    ✗ string evaluator (score: 0.00)
      Expected to contain: '{{expected}}' ⬅️⬅️⬅️⬅️
    ✓ similarity check (score: 0.25)
      LLM evaluation matched choice: '2'
```

__*After*__

```
Running test case 1/1...
  ✗ FAILED
    Model Response: Hello there! How can I assist you today? 😊
    ✓ string evaluator (score: 1.00)
      Expected to contain: 'hello' ⬅️⬅️⬅️⬅️
    ✗ similarity check (score: 0.00)
      LLM evaluation matched choice: '1'
```