### PR TITLE
When evals fail, exit with status code 1

### DIFF
--- a/cmd/eval/eval_test.go
+++ b/cmd/eval/eval_test.go
@@ -291,7 +291,7 @@ evaluators:
 		cmd.SetArgs([]string{promptFile})
 
 		err = cmd.Execute()
-		require.NoError(t, err)
+		require.ErrorIs(t, err, FailedTests)
 
 		output := out.String()
 		require.Contains(t, output, "Failing Test")
@@ -361,7 +361,7 @@ evaluators:
 		cmd.SetArgs([]string{"--json", promptFile})
 
 		err = cmd.Execute()
-		require.NoError(t, err)
+		require.ErrorIs(t, err, FailedTests)
 
 		output := out.String()
 
@@ -534,7 +534,7 @@ evaluators:
 		cmd.SetArgs([]string{"--json", promptFile})
 
 		err = cmd.Execute()
-		require.NoError(t, err)
+		require.ErrorIs(t, err, FailedTests)
 
 		output := out.String()
 


### PR DESCRIPTION
When running evals, I feel its a good idea to exit with status code of 1 that without parsing outputs we can know if evals passed or not.

```shell
Error: ❌ Some tests failed.
exit status 1
```

I did think maybe a CLI flag to invert this behaviour would be cool, but folk smarter than me say its something shell scripts can just do, see: https://github.com/jestjs/jest/issues/10306#issuecomment-663847613