### PR TITLE
Support multiple variables in run

### DIFF
--- a/examples/advanced_template_prompt.yml
+++ b/examples/advanced_template_prompt.yml
@@ -1,0 +1,27 @@
+# Advanced Template Variables Example
+name: Advanced Template Example
+description: Demonstrates advanced usage of template variables
+model: openai/gpt-4o-mini
+modelParameters:
+  temperature: 0.7
+  maxTokens: 300
+messages:
+  - role: system
+    content: |
+      You are {{assistant_persona}}, a {{expertise_level}} {{domain}} specialist.
+      Your communication style should be {{tone}} and {{formality_level}}.
+      
+      Context: You are helping {{user_name}} who works as a {{user_role}} at {{company}}.
+      
+  - role: user
+    content: |
+      Hello! I'm {{user_name}} from {{company}}.
+      
+      Background: {{background_info}}
+      
+      Question: {{input}}
+      
+      Please provide your response considering my role as {{user_role}} and 
+      make it appropriate for a {{formality_level}} setting.
+      
+      Additional context: {{additional_context}}

--- a/examples/template_variables_prompt.yml
+++ b/examples/template_variables_prompt.yml
@@ -1,0 +1,12 @@
+# Example demonstrating arbitrary template variables
+name: Template Variables Example
+description: Shows how to use custom template variables in prompt files
+model: openai/gpt-4o
+modelParameters:
+  temperature: 0.3
+  maxTokens: 200
+messages:
+  - role: system
+    content: You are {{persona}}, a helpful assistant specializing in {{domain}}.
+  - role: user
+    content: Hello {{name}}! I need help with {{topic}}. {{input}}


### PR DESCRIPTION
Supports passing multiple variables to a prompt file with `gh models run`, e.g. `gh models run --file prompt.yml --var name=Alice --var topic="machine learning"`

```
@sgoedecke ➜ /workspaces/gh-models (main) $ ./gh-models run --file examples/template_variables_prompt.yml --var name=S
ean --var topic=Dog --var input=help
Hi there! It seems like you might need some assistance related to dogs.

@sgoedecke ➜ /workspaces/gh-models (main) $ ./gh-models run --file examples/template_variables_prompt.yml --var name=Sean --var topic=Dog --var ="what is my name"
Error: variable key cannot be empty in '=what is my name'
```