### PR TITLE
Support responseFormat in prompt.yml files

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -351,9 +351,17 @@ func NewRunCommand(cfg *command.Config) *cobra.Command {
 					}
 				}
 
-				req := azuremodels.ChatCompletionOptions{
-					Messages: conversation.GetMessages(),
-					Model:    modelName,
+				var req azuremodels.ChatCompletionOptions
+				if pf != nil {
+					// Use the prompt file's BuildChatCompletionOptions method to include responseFormat and jsonSchema
+					req = pf.BuildChatCompletionOptions(conversation.GetMessages())
+					// Override the model name if provided via CLI
+					req.Model = modelName
+				} else {
+					req = azuremodels.ChatCompletionOptions{
+						Messages: conversation.GetMessages(),
+						Model:    modelName,
+					}
 				}
 
 				mp.UpdateRequest(&req)

--- a/examples/json_response_prompt.yml
+++ b/examples/json_response_prompt.yml
@@ -1,0 +1,19 @@
+name: JSON Response Example
+description: Example prompt demonstrating responseFormat with json
+model: openai/gpt-4o
+responseFormat: json
+messages:
+  - role: system
+    content: You are a helpful assistant that responds in JSON format.
+  - role: user
+    content: "Provide a summary of {{topic}} in JSON format with title, description, and key_points array."
+testData:
+  - topic: "artificial intelligence"
+  - topic: "climate change"
+evaluators:
+  - name: contains-json-structure
+    string:
+      contains: "{"
+  - name: has-title
+    string:
+      contains: "title"

--- a/examples/json_response_prompt.yml
+++ b/examples/json_response_prompt.yml
@@ -1,7 +1,7 @@
 name: JSON Response Example
 description: Example prompt demonstrating responseFormat with json
 model: openai/gpt-4o
-responseFormat: json
+responseFormat: json_object
 messages:
   - role: system
     content: You are a helpful assistant that responds in JSON format.

--- a/examples/json_schema_prompt.yml
+++ b/examples/json_schema_prompt.yml
@@ -3,45 +3,48 @@ description: Example prompt demonstrating responseFormat and jsonSchema usage
 model: openai/gpt-4o
 responseFormat: json_schema
 jsonSchema:
-  type: object
-  description: A structured response containing person information
-  properties:
-    name:
-      type: string
-      description: The full name of the person
-    age:
-      type: integer
-      description: The age of the person in years
-      minimum: 0
-      maximum: 150
-    email:
-      type: string
-      description: The email address of the person
-      format: email
-    skills:
-      type: array
-      description: A list of skills the person has
-      items:
+  name: Person Information Schema
+  strict: true
+  schema:
+    type: object
+    description: A structured response containing person information
+    properties:
+      name:
         type: string
-    address:
-      type: object
-      description: The person's address
-      properties:
-        street:
+        description: The full name of the person
+      age:
+        type: integer
+        description: The age of the person in years
+        minimum: 0
+        maximum: 150
+      email:
+        type: string
+        description: The email address of the person
+        format: email
+      skills:
+        type: array
+        description: A list of skills the person has
+        items:
           type: string
-          description: Street address
-        city:
-          type: string
-          description: City name
-        country:
-          type: string
-          description: Country name
-      required:
-        - city
-        - country
-  required:
-    - name
-    - age
+      address:
+        type: object
+        description: The person's address
+        properties:
+          street:
+            type: string
+            description: Street address
+          city:
+            type: string
+            description: City name
+          country:
+            type: string
+            description: Country name
+        required:
+          - city
+          - country
+    required:
+      - name
+      - age
 messages:
   - role: system
     content: You are a helpful assistant that provides structured information about people.

--- a/examples/json_schema_prompt.yml
+++ b/examples/json_schema_prompt.yml
@@ -1,0 +1,61 @@
+name: JSON Schema Response Example
+description: Example prompt demonstrating responseFormat and jsonSchema usage
+model: openai/gpt-4o
+responseFormat: json_schema
+jsonSchema:
+  type: object
+  description: A structured response containing person information
+  properties:
+    name:
+      type: string
+      description: The full name of the person
+    age:
+      type: integer
+      description: The age of the person in years
+      minimum: 0
+      maximum: 150
+    email:
+      type: string
+      description: The email address of the person
+      format: email
+    skills:
+      type: array
+      description: A list of skills the person has
+      items:
+        type: string
+    address:
+      type: object
+      description: The person's address
+      properties:
+        street:
+          type: string
+          description: Street address
+        city:
+          type: string
+          description: City name
+        country:
+          type: string
+          description: Country name
+      required:
+        - city
+        - country
+  required:
+    - name
+    - age
+messages:
+  - role: system
+    content: You are a helpful assistant that provides structured information about people.
+  - role: user
+    content: "Generate information for a person named {{name}} who is {{age}} years old."
+testData:
+  - name: "Alice Johnson"
+    age: "30"
+  - name: "Bob Smith"
+    age: "25"
+evaluators:
+  - name: has-required-fields
+    string:
+      contains: "name"
+  - name: valid-json-structure
+    string:
+      contains: "age"

--- a/internal/azuremodels/types.go
+++ b/internal/azuremodels/types.go
@@ -6,6 +6,23 @@ import (
 	"github.com/github/gh-models/internal/sse"
 )
 
+// ChatCompletionOptions represents available options for a chat completion request.
+type ChatCompletionOptions struct {
+	MaxTokens      *int            `json:"max_tokens,omitempty"`
+	Messages       []ChatMessage   `json:"messages"`
+	Model          string          `json:"model"`
+	Stream         bool            `json:"stream,omitempty"`
+	Temperature    *float64        `json:"temperature,omitempty"`
+	TopP           *float64        `json:"top_p,omitempty"`
+	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`
+}
+
+// ResponseFormat represents the response format specification
+type ResponseFormat struct {
+	Type       string                  `json:"type"`
+	JsonSchema *map[string]interface{} `json:"json_schema,omitempty"`
+}
+
 // ChatMessageRole represents the role of a chat message.
 type ChatMessageRole string
 
@@ -22,16 +39,6 @@ const (
 type ChatMessage struct {
 	Content *string         `json:"content,omitempty"`
 	Role    ChatMessageRole `json:"role"`
-}
-
-// ChatCompletionOptions represents available options for a chat completion request.
-type ChatCompletionOptions struct {
-	MaxTokens   *int          `json:"max_tokens,omitempty"`
-	Messages    []ChatMessage `json:"messages"`
-	Model       string        `json:"model"`
-	Stream      bool          `json:"stream,omitempty"`
-	Temperature *float64      `json:"temperature,omitempty"`
-	TopP        *float64      `json:"top_p,omitempty"`
 }
 
 // ChatChoiceMessage is a message from a choice in a chat conversation.


### PR DESCRIPTION
https://github.com/github/models/issues/2522

The CLI supports prompt.yml files, but it doesn't support json or json schema outputs. This PR adds that support.

Diff is mostly tests and fixtures.